### PR TITLE
Extend composite action to support solr #9

### DIFF
--- a/.github/actions/setup_archivesspace/action.yml
+++ b/.github/actions/setup_archivesspace/action.yml
@@ -10,10 +10,18 @@ inputs:
   plugin:
     description: Optional plugin to checkout and add to config
     required: false
+  solr-enabled:
+    description: Is solr enabled?
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    - uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version || 11 }}
+        distribution: temurin
+
     - name: Allow ArchivesSpace functions for app db user
       if: ${{ inputs.db-port }}
       shell: bash
@@ -25,6 +33,22 @@ runs:
       with:
         ref: ${{ inputs.archivesspace-version }}
         repository: Smithsonian/archivesspace
+    
+    - name: Copy solr config from workspace to solr service
+      if: ${{ inputs.solr-enabled }}
+      shell: bash
+      env:
+        SOLR_ID: ${{ job.services.solr.id }}
+      run: |
+        docker cp solr $SOLR_ID:/solr_conf_from_repo
+  
+    - name: Create ArchivesSpace Solr core
+      if: ${{ inputs.solr-enabled }}
+      shell: bash
+      env:
+        SOLR_ID: ${{ job.services.solr.id }}
+      run: |
+        docker exec --tty $SOLR_ID solr create_core -p 8983 -c archivesspace -d /solr_conf_from_repo
   
     - name: Checkout plugin
       if: ${{ inputs.plugin }}


### PR DESCRIPTION
## Description
Frontend test setup was added via https://github.com/Smithsonian/caas_aspace_refid/pull/47 in a hurry, but this extends that setup to our shared repo so it can be repurposed across plugin repositories.

## Related GitHub Issue
Closes #9 

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
NA: This is a developer convenience only, so skipping a formal review
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
NA
- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
NA
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
