### PR TITLE
Add v4.1.0 to diff workflow #11

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -11,7 +11,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        archivesspace_version: [v3.3.1, v3.4.1, v3.5.1, v4.0.0]
+        archivesspace_version: [v3.3.1, v4.0.0, v4.1.0]
     steps:
 
     - name: Checkout current plugin


### PR DESCRIPTION
## Description
Just a chore to aid in our migration planning to 4.1.0.  Removes our diff checks against ArchivesSpace versions 3.4.x and 3.5.x (since we'll be skipping those entirely), and adds a diff check for v4.1.0 (our new target version).

## Related GitHub Issue
Closes #11 

## Testing
N/A

## Screenshot(s):
N/A

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
N/A
- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
N/A - the checks will run in other repos, this is just the shared workflow
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
