### PR TITLE
13 optional input

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -11,7 +11,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     env:
-      PROD_ARCHIVESSPACE_VERSION: (${{ inputs.prod_archivesspace_version }} || v3.3.1)
+      PROD_ARCHIVESSPACE_VERSION: ${{ inputs.prod_archivesspace_version || 'v3.3.1' }}
     continue-on-error: true
     strategy:
       matrix:


### PR DESCRIPTION
## Description
There may be times where we want to override the default env var that sets the production aspace version for the diff check.  For example, we're testing a new version of a plugin that will be used against and upgraded version of archivesspace.  This just adds an optional input to the shared workflow that allows calls to that workflow to set their own production aspace version.  (See, for example, https://github.com/Smithsonian/caas_aspace_sova_button/pull/20)

## Related GitHub Issue
Closes #13 

## Testing
Tests called both [with](https://github.com/lorawoodford/caas_aspace_sova_button/actions/runs/15349558316/job/43194489416) and [without](https://github.com/lorawoodford/caas_aspace_refid/actions/runs/15349815214/job/43194926269) the optional input from other repos passing fine.

## Screenshot(s):
N/A

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
Skipping for such a minor, optional change.
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
N/A
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
